### PR TITLE
ヘッダーにグループの要素を表示

### DIFF
--- a/app/views/messages/index.html.haml
+++ b/app/views/messages/index.html.haml
@@ -3,7 +3,7 @@
   .chat-main__header
     .chat-main__header--top
       .chat-main__header--name
-        sample-group-name
+        = @group.name
       = link_to "", class: "chat-main__header--edit-btn" do
         Edit
     .chat-main__header--bottom

--- a/app/views/messages/index.html.haml
+++ b/app/views/messages/index.html.haml
@@ -9,7 +9,8 @@
     .chat-main__header--bottom
       MEMBER:
       %i
-        sample-user-name sample-user-name sample-user-name sample-user-name sample-user-name sample-user-name sample-user-name sample-user-name
+        - @group.users.each do |user|
+          = user.name
   .chat-main__body
     .chat-main__body--messages
       = render @messages

--- a/app/views/messages/index.html.haml
+++ b/app/views/messages/index.html.haml
@@ -4,7 +4,7 @@
     .chat-main__header--top
       .chat-main__header--name
         = @group.name
-      = link_to "", class: "chat-main__header--edit-btn" do
+      = link_to edit_group_path(@group), class: "chat-main__header--edit-btn" do
         Edit
     .chat-main__header--bottom
       MEMBER:


### PR DESCRIPTION
#What
ヘッダーにグループの要素を表示する。
（グループ名、属するユーザーの名前、グループ編集画面へのリンク）

#Why
サービスに必須の機能のため。